### PR TITLE
添加本科生毕业论文typst模版

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,4 @@
 2. TIS-教务系统拓展选课脚本.js by @Fros1er [📁仓库](https://github.com/Fros1er/SUSTechTISHelper)
 3. TIS-教务系统中考试成绩导出为Excel表格 by @lethal233 [📁仓库](https://github.com/lethal233/sustech-tis-converter)
 4. IPTV电视直播 by @liziwl：[📁仓库](https://github.com/liziwl/iptv-panel-react)
+5. 南科大本科生毕业论文 Typst 模版 by @dazhi0619 [📁仓库](https://github.com/dazhi0619/sustech-ug-thesis-typst)


### PR DESCRIPTION
我自己制作了本科生毕业论文的typst模版，给其他毕业年级希望用typst写毕业论文的同学参考使用。